### PR TITLE
Fix typo in README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This application must:
 - Receive a streaming of employee's quotes and store them
 - Search a Trivia about the employees in an external service
 
-### (Theorical) Pro environment
+### (Theoretical) Pro environment
 
 ![localstack-pro_environment.png](doc/localstack-pro_environment.png)
 


### PR DESCRIPTION
## Summary
- fix the spelling of the "Theoretical" heading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68481391467c8329b3c779a4c1f6a801